### PR TITLE
Service map should read services only from its own namespace

### DIFF
--- a/apiman/src/main/java/io/fabric8/apiman/KubernetesServiceCatalog.java
+++ b/apiman/src/main/java/io/fabric8/apiman/KubernetesServiceCatalog.java
@@ -115,7 +115,7 @@ public class KubernetesServiceCatalog implements IApiCatalog  {
 	    }
 	    osClient.close();
 
-		Map<String, Service> serviceMap = KubernetesHelper.getServiceMap(kubernetes);
+	    Map<String, Service> serviceMap = KubernetesHelper.getServiceMap(kubernetes, osClient.getNamespace());
 
 	    for (String serviceName : serviceMap.keySet()) {
 			if (keyword==null || keyword.equals("") || keyword.equals("*") || serviceName.toLowerCase().contains(keyword.toLowerCase())) {


### PR DESCRIPTION
When importing services to apiman from Kubernetes it is necessary to import services from only its own namespaces. Otherwise it could present a security risk and would require unnecessary escalation of privileges.