### PR TITLE
Issue 310

### DIFF
--- a/apiman-gateway/pom.xml
+++ b/apiman-gateway/pom.xml
@@ -196,6 +196,7 @@
         <fabric8.volume.keystore.mountPath>/secret/apiman-gateway</fabric8.volume.keystore.mountPath>
         <fabric8.annotations.service.api.service.kubernetes.io.scheme>https</fabric8.annotations.service.api.service.kubernetes.io.scheme>
         <fabric8.readinessProbe.httpGet.scheme>HTTPS</fabric8.readinessProbe.httpGet.scheme>
+        <fabric8.extra.json>${basedir}/src/main/resources/route-tls-passthrough.json</fabric8.extra.json>
       </properties>
       <build>
         <plugins>

--- a/apiman-gateway/src/main/resources/route-tls-passthrough.json
+++ b/apiman-gateway/src/main/resources/route-tls-passthrough.json
@@ -1,0 +1,18 @@
+{
+  "kind": "Route",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "apiman-gateway",
+    "namespace": "default"
+  },
+  "spec": {
+    "host": "apiman.vagrant.f8",
+    "to": {
+      "kind": "Service",
+      "name": "apiman-gateway"
+    },
+    "tls": {
+      "termination": "passthrough"
+    }
+  }
+}

--- a/apiman/pom.xml
+++ b/apiman/pom.xml
@@ -43,8 +43,6 @@
     <fabric8.readinessProbe.timeoutSeconds>60</fabric8.readinessProbe.timeoutSeconds>
     <fabric8.readinessProbe.initialDelaySeconds>15</fabric8.readinessProbe.initialDelaySeconds>
 
-    <fabric8.extra.json>${basedir}/src/main/resources/route-tls-passthrough.json</fabric8.extra.json>
-
   </properties>
 
   <dependencyManagement>
@@ -248,6 +246,7 @@
         <fabric8.volume.keystore.mountPath>/secret/apiman</fabric8.volume.keystore.mountPath>
         <fabric8.annotations.service.api.service.kubernetes.io.scheme>https</fabric8.annotations.service.api.service.kubernetes.io.scheme>
         <fabric8.readinessProbe.httpGet.scheme>HTTPS</fabric8.readinessProbe.httpGet.scheme>
+        <fabric8.extra.json>${basedir}/src/main/resources/route-tls-passthrough.json</fabric8.extra.json>
       </properties>
       <build>
         <plugins>

--- a/apiman/pom.xml
+++ b/apiman/pom.xml
@@ -43,6 +43,8 @@
     <fabric8.readinessProbe.timeoutSeconds>60</fabric8.readinessProbe.timeoutSeconds>
     <fabric8.readinessProbe.initialDelaySeconds>15</fabric8.readinessProbe.initialDelaySeconds>
 
+    <fabric8.extra.json>${basedir}/src/main/resources/route-tls-passthrough.json</fabric8.extra.json>
+
   </properties>
 
   <dependencyManagement>

--- a/apiman/src/main/resources/route-tls-passthrough.json
+++ b/apiman/src/main/resources/route-tls-passthrough.json
@@ -1,0 +1,18 @@
+{
+  "kind": "Route",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "apiman",
+    "namespace": "default"
+  },
+  "spec": {
+    "host": "apiman.vagrant.f8",
+    "to": {
+      "kind": "Service",
+      "name": "apiman"
+    },
+    "tls": {
+      "termination": "passthrough"
+    }
+  }
+}


### PR DESCRIPTION
- Add as extra json file to define the Secured TLS Route using as Termination = passthrough 
- Setup extra json file as fabric8 property within the pom.xml file under profile ssl