### PR TITLE
Prevented change of the connection factory by the spring-boot framework

### DIFF
--- a/camel-amq/pom.xml
+++ b/camel-amq/pom.xml
@@ -35,6 +35,9 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
 
+    <!-- Spring-boot version, used for testing purposes only -->
+    <spring-boot.version>1.3.5.RELEASE</spring-boot.version>
+
     <fuse.osgi.export>io.fabric8.mq.camel;version=${fuse.osgi.version};-noimport:=true</fuse.osgi.export>
 
     <!-- lets explicitly import the mq-fabric and cf code -->
@@ -119,6 +122,22 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-spring-boot</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>${spring-boot.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/camel-amq/src/main/java/io/fabric8/mq/camel/AMQConfiguration.java
+++ b/camel-amq/src/main/java/io/fabric8/mq/camel/AMQConfiguration.java
@@ -21,6 +21,8 @@ import org.apache.activemq.camel.component.ActiveMQConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.jms.ConnectionFactory;
+
 /**
  * A configuration object for the {@link AMQComponent} which uses Kubernetes service wiring
  * to find the correct ActiveMQ broker service to communicate with
@@ -34,14 +36,14 @@ public class AMQConfiguration extends ActiveMQConfiguration {
     public AMQConfiguration() {
         // use MQConnectionFactory as the out of the box connection factory
         // as it can lookup the ActiveMQ broker using kubernetes services and the ENV variables
-        setConnectionFactory(new MQConnectionFactory());
+        super.setConnectionFactory(new MQConnectionFactory());
     }
 
     public AMQConfiguration(AMQComponent component) {
         super.setActiveMQComponent(component);
         // use MQConnectionFactory as the out of the box connection factory
         // as it can lookup the ActiveMQ broker using kubernetes services and the ENV variables
-        setConnectionFactory(new MQConnectionFactory());
+        super.setConnectionFactory(new MQConnectionFactory());
     }
 
     @Override
@@ -78,6 +80,11 @@ public class AMQConfiguration extends ActiveMQConfiguration {
         this.failoverUrlParameters = failoverUrlParameters;
     }
 
+    @Override
+    public void setConnectionFactory(ConnectionFactory connectionFactory) {
+        // noop
+        // the connectionFactory cannot be changed
+    }
 
     // TODO if ever ActiveMQConfiguration provides a template method
     // to create a vanilla ActiveMQConnectionFactory before its wrapped in pooling

--- a/camel-amq/src/test/java/io/fabric8/mq/camel/AmqSpringBootTest.java
+++ b/camel-amq/src/test/java/io/fabric8/mq/camel/AmqSpringBootTest.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright 2005-2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.mq.camel;
+
+import io.fabric8.mq.core.MQConnectionFactory;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.test.spring.CamelSpringJUnit4ClassRunner;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+
+import javax.jms.ConnectionFactory;
+
+@RunWith(CamelSpringJUnit4ClassRunner.class)
+@SpringBootApplication
+@SpringApplicationConfiguration(classes = AmqSpringBootTest.class)
+public class AmqSpringBootTest {
+
+    @Autowired
+    private CamelContext camelContext;
+
+    @Test
+    public void testConnectionFactoryKept() throws Exception {
+        Endpoint endpoint = camelContext.getEndpoint("amq:springQueue");
+
+        AMQComponent amq = (AMQComponent) camelContext.getComponent("amq");
+        AMQConfiguration config = amq.getConfiguration();
+        ConnectionFactory factory = config.getConnectionFactory();
+
+        Assert.assertTrue("The connection factory is not an instance of " + MQConnectionFactory.class.getName(), factory instanceof MQConnectionFactory);
+    }
+
+}


### PR DESCRIPTION
I found a subtle issue while trying to use the camel-amq module in spring boot.
 The JMS configuration *always used an embedded JMS broker, instead of trying to look up the Kubernetes broker services*.

This happens because the Spring framework finds a different implementation of the `ConnectionFactory` interface (one that creates and connects to the embedded broker) in the Spring context and assign it to the `AMQConfiguration` object. 

I just prevented such change and added unit tests to verify it works as expected.